### PR TITLE
pass db connection to go migration script

### DIFF
--- a/_example/migrations/20130106222315_and_again.go
+++ b/_example/migrations/20130106222315_and_again.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 )
 
-func Up_20130106222315(txn *sql.Tx) {
+func Up_20130106222315(txn *sql.Tx, db *sql.DB) {
 	fmt.Println("Hello from migration 20130106222315 Up!")
 }
 
-func Down_20130106222315(txn *sql.Tx) {
+func Down_20130106222315(txn *sql.Tx, db *sql.DB) {
 	fmt.Println("Hello from migration 20130106222315 Down!")
 }

--- a/templates.go
+++ b/templates.go
@@ -77,7 +77,7 @@ func main() {
 		log.Fatal("db.Begin:", err)
 	}
 
-	{{ .Func }}(txn)
+	{{ .Func }}(txn, db)
 
 	err = goose.FinalizeMigration(&conf, txn, goose.{{ .Direction }}, {{ .Version }})
 	if err != nil {
@@ -109,12 +109,12 @@ import (
 )
 
 // Up is executed when this migration is applied
-func Up_{{ . }}(txn *sql.Tx) {
+func Up_{{ . }}(txn *sql.Tx, db *sql.DB) {
 
 }
 
 // Down is executed when this migration is rolled back
-func Down_{{ . }}(txn *sql.Tx) {
+func Down_{{ . }}(txn *sql.Tx, db *sql.DB) {
 
 }
 {{/* vim: set ft=go.gotexttmpl: */}}

--- a/templates/migration-main.go.tmpl
+++ b/templates/migration-main.go.tmpl
@@ -28,7 +28,7 @@ func main() {
 		log.Fatal("db.Begin:", err)
 	}
 
-	{{ .Func }}(txn)
+	{{ .Func }}(txn, db)
 
 	err = goose.FinalizeMigration(&conf, txn, goose.{{ .Direction }}, {{ .Version }})
 	if err != nil {

--- a/templates/migration.go.tmpl
+++ b/templates/migration.go.tmpl
@@ -5,12 +5,12 @@ import (
 )
 
 // Up is executed when this migration is applied
-func Up_{{ . }}(txn *sql.Tx) {
+func Up_{{ . }}(txn *sql.Tx, db *sql.DB) {
 
 }
 
 // Down is executed when this migration is rolled back
-func Down_{{ . }}(txn *sql.Tx) {
+func Down_{{ . }}(txn *sql.Tx, db *sql.DB) {
 
 }
 {{/* vim: set ft=go.gotexttmpl: */}}


### PR DESCRIPTION
... so that other libraries (such as https://github.com/jinzhu/gorm) can reuse the db connection.

For example:

``` go
func Up_20160221232922(txn *sql.Tx, db *sql.DB) {
    gdb, _ := gorm.Open("postgres", db)
    gdb.CreateTable(&models.User{})
}

func Down_20160221232922(txn *sql.Tx, db *sql.DB) {
    gdb, _ := gorm.Open("postgres", db)
    gdb.DropTable(&models.User{})
}
```

Original PR: https://bitbucket.org/liamstask/goose/pull-requests/54/pass-db-connection-to-go-migration-script/diff
